### PR TITLE
feat(moon mage): cast shadows as backup

### DIFF
--- a/burgle.cmd
+++ b/burgle.cmd
@@ -161,7 +161,10 @@ BUFF:
 	}
 	if ("$guild"="Moon Mage") then 
 	{
+		# Buff stealth with either refractive field or shadows.
+		# If you don't know, or didn't cast, refractive field then we try shadows.
 		if ($SpellTimer.RefractiveField.active = 0) then gosub CAST RF
+		if ($SpellTimer.RefractiveField.active != 1 && $SpellTimer.Shadows.active = 0) then gosub CAST SHADOW
 	}
 	goto GETREADY
 


### PR DESCRIPTION
For moon mages who don't know [Refractive Field](https://elanthipedia.play.net/Refractive_Field) spell, the [Shadows](https://elanthipedia.play.net/Shadows) spell can be a good alternative to boost their stealth skill while burgling in hopes [to reduce the round time when hiding](https://elanthipedia.play.net/Stealth_skill#Hide_Roundtimes) in a room.

Line 167 checks if `$SpellTimer.RefractiveField.active != 1` rather than check if it's still `0` because if the character does not know Refractive Field spell, or has never cast it with the SpellTimer plugin enabled, then the variable `$SpellTimer.RefractiveField.active` will NOT exist and so that expression won't yield a number but rather the plain text value **$SpellTimer.RefractiveField.active**. Checking if the variable **is not 1** handles both cases where either (a) the spell didn't cast successfully or (b) the spelltimer variable doesn't exist.