### PR TITLE
feat(thief): khri darken as backup

### DIFF
--- a/burgle.cmd
+++ b/burgle.cmd
@@ -173,7 +173,7 @@ KHRI:
 	KHRI1:
 	var last KHRI1
 	matchre KNEEL ^\[Sitting\, kneeling\, or lying down can make starting this khri easier\.\]
-	matchre RETURN ^Your hand twitches|^Slipping into the proper|^Centering your mind|^Turning inwards
+	matchre RETURN ^Your hand twitches|^Slipping into the proper|^Centering your mind|^Turning inwards|^Focusing your mind
 	matchre RETURN ^You have not recovered from your previous use|^Your body is willing, but|^You're already using
 	matchre WAIT \.\.\.wait|still stunned|^Sorry, you may only
 	put khri %khri

--- a/burgle.cmd
+++ b/burgle.cmd
@@ -148,7 +148,10 @@ BUFF:
 		send khri check
 		matchwait 6
 		if ($concentration < 55) then gosub CONC_REGEN
+		# Buff stealth with either silence or darken.
+		# If you don't know, or didn't apply, silence then we try darken.
 		if ($SpellTimer.KhriSilence.active = 0) then gosub KHRI SILENCE
+		if ($SpellTimer.KhriSilence.active != 1 && $SpellTimer.KhriDarken.active = 0) then gosub KHRI DARKEN
 		if ($SpellTimer.KhriPlunder.active = 0) then gosub KHRI PLUNDER
 		if ($SpellTimer.KhriSlight.active = 0) then gosub KHRI SLIGHT
 		if ($SpellTimer.KhriHasten.active = 0) then gosub KHRI HASTEN

--- a/burgle.cmd
+++ b/burgle.cmd
@@ -174,7 +174,7 @@ KHRI:
 	var last KHRI1
 	matchre KNEEL ^\[Sitting\, kneeling\, or lying down can make starting this khri easier\.\]
 	matchre RETURN ^Your hand twitches|^Slipping into the proper|^Centering your mind|^Turning inwards|^Focusing your mind
-	matchre RETURN ^You have not recovered from your previous use|^Your body is willing, but|^You're already using
+	matchre RETURN ^You have not recovered from your previous use|^Your body is willing, but|^You're already using|^Your recent use of
 	matchre WAIT \.\.\.wait|still stunned|^Sorry, you may only
 	put khri %khri
 	matchwait 5


### PR DESCRIPTION
For thieves who don't know [Silence](https://elanthipedia.play.net/Khri_Silence) khri, the [Darken](https://elanthipedia.play.net/Khri_Darken) khri can be a good alternative to boost their stealth skill while burgling in hopes [to reduce the round time when hiding](https://elanthipedia.play.net/Stealth_skill#Hide_Roundtimes) in a room.

Line 154 checks if `$SpellTimer.KhriSilence.active != 1` rather than check if it's still `0` because if the character does not know Silence khri, or has never cast it with the SpellTimer plugin enabled, then the variable `$SpellTimer.KhriSilence.active` will NOT exist and so that expression won't yield a number but rather the plain text value **$SpellTimer.KhriSilence.active**. Checking if the variable **is not 1** handles both cases where either (a) the khri didn't activate successfully or (b) the spelltimer variable doesn't exist.